### PR TITLE
fix: breaking change for pgvecto_rs

### DIFF
--- a/engine/clients/pgvector/config.py
+++ b/engine/clients/pgvector/config.py
@@ -13,9 +13,9 @@ DISTANCE_MAPPING_CREATE = {
 }
 
 DISTANCE_MAPPING_CREATE_RUST = {
-    Distance.L2: "l2_ops",
-    Distance.COSINE: "cosine_ops",
-    Distance.DOT: "dot_ops",
+    Distance.L2: "vector_l2_ops",
+    Distance.COSINE: "vector_cos_ops",
+    Distance.DOT: "vector_dot_ops",
 }
 
 DISTANCE_MAPPING_SEARCH = {

--- a/engine/clients/pgvector/search.py
+++ b/engine/clients/pgvector/search.py
@@ -33,12 +33,7 @@ class PGVectorSearcher(BaseSearcher):
             cur.execute("BEGIN;")
             # set index create parameter
             for key in cls.search_params["params"].keys():
-                if cls.engine_type == "c":
-                    cur.execute(f"SET LOCAL {key} = {cls.search_params['params'][key]};")
-                else:
-                    # pgvector_rs only support hnsw
-                    cur.execute(f"SET LOCAL vectors.k = {cls.search_params['params']['hnsw.ef_search']};")
-                    break
+                cur.execute(f"SET LOCAL {key} = {cls.search_params['params'][key]};")
 
             meta_conditions = cls.parser.parse(meta_conditions)
             if meta_conditions:

--- a/experiments/needs_editing/pgvector_rust_HNSW_single_node_laion-768-5m-ip.json
+++ b/experiments/needs_editing/pgvector_rust_HNSW_single_node_laion-768-5m-ip.json
@@ -6,7 +6,7 @@
     "platform": "CloudTest_v0.0.4",
     "index_type": "HNSW",
     "dataset": "laion-768-5m-ip",
-    "version": "pg15-latest",
+    "version": "pg16-v0.2.0",
     "branch": "master",
     "commit": "sha256:38c7e5c4fa3afd48fb4911b3f96489ac287b59f8bfdd9b7b55c0eca898ffec21",
     "remark": "pgvector implemented in RUST",
@@ -24,28 +24,28 @@
         "parallel": 4,
         "top": 10,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100
         }
       },
       {
         "parallel": 4,
         "top": 100,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100
         }
       },
       {
         "parallel": 8,
         "top": 10,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100
         }
       },
       {
         "parallel": 8,
         "top": 100,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100
         }
       }
     ],
@@ -53,8 +53,10 @@
       "parallel": 16,
       "batch_size": 64,
       "index_params": {
-        "m": 12,
-        "ef_construction": 100
+        "indexing.hnsw.m": 12,
+        "indexing.hnsw.ef_construction": 100,
+        "optimizing.optimizing_threads": 8,
+        "segment.max_sealed_segment_size": 5000000
       },
       "index_type": "hnsw",
       "engine_type": "rust"

--- a/experiments/needs_editing/pgvector_rust_HNSW_single_node_laion-768-5m-probability-ip.json
+++ b/experiments/needs_editing/pgvector_rust_HNSW_single_node_laion-768-5m-probability-ip.json
@@ -6,7 +6,7 @@
     "platform": "CloudTest_v0.0.4",
     "index_type": "HNSW",
     "dataset": "laion-768-5m-ip-probability",
-    "version": "pg15-latest",
+    "version": "pg16-v0.2.0",
     "branch": "master",
     "commit": "sha256:38c7e5c4fa3afd48fb4911b3f96489ac287b59f8bfdd9b7b55c0eca898ffec21",
     "remark": "pgvector implemented in RUST",
@@ -24,7 +24,8 @@
         "parallel": 4,
         "top": 10,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.01
@@ -34,7 +35,8 @@
         "parallel": 4,
         "top": 10,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.1
@@ -44,7 +46,8 @@
         "parallel": 4,
         "top": 100,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.01
@@ -54,7 +57,8 @@
         "parallel": 4,
         "top": 100,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.1
@@ -64,7 +68,8 @@
         "parallel": 8,
         "top": 10,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.01
@@ -74,7 +79,8 @@
         "parallel": 8,
         "top": 10,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.1
@@ -84,7 +90,8 @@
         "parallel": 8,
         "top": 100,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.01
@@ -94,7 +101,8 @@
         "parallel": 8,
         "top": 100,
         "params": {
-          "hnsw.ef_search": 100
+          "vectors.hnsw_ef_search": 100,
+          "vectors.search_mode": "vbase"
         },
         "query_meta": {
           "probability": 0.1
@@ -105,8 +113,10 @@
       "parallel": 16,
       "batch_size": 64,
       "index_params": {
-        "m": 12,
-        "ef_construction": 100
+        "indexing.hnsw.m": 12,
+        "indexing.hnsw.ef_construction": 100,
+        "optimizing.optimizing_threads": 8,
+        "segment.max_sealed_segment_size": 5000000
       },
       "index_type": "hnsw",
       "engine_type": "rust"


### PR DESCRIPTION
Benchmark results in aws [r6a.xlarge](https://aws.amazon.com/cn/ec2/instance-types/r6a/) (4 vCPU, 32 GB) for reference

pgvector_rust_HNSW_single_node_laion-768-5m-ip:
| num | precisions | rps    |
| --- | ---------- | ------ |
| 1   | 93.64%     | 764.39 |
| 2   | 88.39%     | 405.74 |
| 3   | 93.75%     | 763.15 |
| 4   | 88.49%     | 434.92 |

pgvector_rust_HNSW_single_node_laion-768-5m-probability-ip:
| num | precisions | rps    |
| --- | ---------- | ------ |
| 1   | 93.07%     | 95.46  |
| 2   | 89.57%     | 511.88 |
| 3   | 94.49%     | 10.70  |
| 4   | 93.10%     | 86.78  |
| 5   | 93.13%     | 94.83  |
| 6   | 89.68%     | 500.15 |
| 7   | 94.46%     | 10.38  |
| 8   | 93.18%     | 85.12  |